### PR TITLE
Update setup.py to use tensorflow==2.0.0 as requirement.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
 	python_requires='>=3.6',
 	install_requires=[
 		'cloudpickle',
-		'tensorflow==2.0.0-beta0',
+		'tensorflow==2.0.0',
 		'scipy',
 	],
 	packages=find_packages()


### PR DESCRIPTION
Updates setup.py to use tensorflow==2.0.0 as requirement now that it is officially released.